### PR TITLE
Add Quiet and Silent switches

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -6,6 +6,7 @@
 
 - Copyright 2021 Troy Southard <troy.southard@us.af.mil>
 - Copyright 2022 Nick Little <nicklaus.little@gmail.com>
+- Copyright 2022 Thomas Bateson <thomas.bateson@eagles.oc.edu>
 - _Add the copyright date, your name, and email address here. (PLEASE KEEP THIS LINE)_
 
 ## Note for U.S. Federal Employees

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ A `pwr.json` might look like:
 ```json
 {
     "packages": [
-        "java:8",
+        "jdk:8",
         "python"
     ],
     "repositories": [
@@ -64,12 +64,11 @@ A `pwr.json` might look like:
 | Name | Default Value | Description |
 |--|--|--|
 | `PwrHome` | `$env:AppData\pwr` | The location `pwr` uses for package storage and other data caching. |
-| `PwrWebPath` | `C:\Windows\System32\curl.exe` | All web requests will use the provided executable. It must conform to the `curl` command line interface. |
 
 # Usage
 
 	SYNTAX
-	pwr [[-Command] <String>] [[-Packages] <String[]>] [-Repositories <String[]>] [-Fetch] [-Installed] [-AssertMinimum <String>] [-DaysOld <Int32>] [-Offline] [-Override] [-WhatIf] [-Confirm] [<CommonParameters>]
+	pwr [[-Command] <String>] [[-Packages] <String[]>] [-Repositories <String[]>] [-Fetch] [-Installed] [-AssertMinimum <String>] [-DaysOld <Int32>] [-Offline] [-Quiet] [-Silent] [-Override] [-Run <String>] [-WhatIf] [-Confirm] [<CommonParameters>]
 
 	PARAMETERS
 	 -Command <String>
@@ -112,6 +111,12 @@ A `pwr.json` might look like:
 
 	-Offline [<SwitchParameter>]
 		Prevents attempts to request a web resource
+
+	-Quiet [<SwitchParameter>]
+		Suppresses all output to stdout
+
+	-Silent [<SwitchParameter>]
+		Suppresses all output to stdout and stderr
 
 	-AssertMinimum <String>
 		Writes an error if the provided semantic version (a.b.c) is not met by this scripts version


### PR DESCRIPTION
- Added `-Quiet` and `-Silent` switches to suppress output; `-Quiet` suppresses `stdout`, `-Silent` suppresses `stderr` and `stdout`
    - `-Silent` only covers errors reported by `pwr.ps1`, not sure about errors reported by other executables
- Partially fixed `-Offline`, it was still fetching even when specified; I fixed this by moving the handling of offline to earlier in the processing
- Fixed variable style from `$var` -> `$Var`
- Removed `PwrWebPath` environment variable usage