### PR TITLE
Fix usage of Write-Output

### DIFF
--- a/src/pwr.ps1
+++ b/src/pwr.ps1
@@ -176,7 +176,7 @@ function Write-Pwr($Message, $ForegroundColor, [switch]$NoNewline, [switch]$Over
 			Write-Host $Message -NoNewline:$NoNewline
 		}
 	} else {
-		Write-Output "pwr: $Message"
+		Write-Output "pwr: $Message" | Out-Default
 	}
 }
 
@@ -188,7 +188,7 @@ function Write-PwrOutput($Message, $ForegroundColor, [switch]$NoNewline) {
 
 function Write-PwrHost($Message) {
 	if (-not $Quiet -and -not $Silent) {
-		Write-Output $Message
+		Write-Output $Message | Out-Default
 	}
 }
 

--- a/test/run.ps1
+++ b/test/run.ps1
@@ -199,6 +199,13 @@ function Test-Pwr-ShellEnvOther {
 	}
 }
 
+function Test-Pwr-ShellGetPkg {
+	pwr sh pwr; pwr exit
+	Invoke-PwrAssertTrue {
+		$LastExitCode -eq 0
+	}
+}
+
 function Test-Pwr-AltConfig {
 	pwr sh "file:///$PSScriptRoot\pkg3 < alt"
 	Invoke-PwrAssertTrue {


### PR DESCRIPTION
Fixes problem with Write-Output that was causing functions using it to return the output string in the output stream. 