### PR TITLE
Remove offset when considering write to host

### DIFF
--- a/src/pwr.ps1
+++ b/src/pwr.ps1
@@ -97,7 +97,7 @@ param (
 	[string[]]$Run
 )
 
-$WriteToHost = ($MyInvocation.ScriptLineNumber -eq 1) -and ($MyInvocation.OffsetInLine -eq 1) -and ($MyInvocation.PipelineLength -eq 1)
+$WriteToHost = ($MyInvocation.ScriptLineNumber -eq 1) -and ($MyInvocation.PipelineLength -eq 1)
 
 function Write-Pwr($Message, $ForegroundColor, [switch]$NoNewline, [switch]$Override) {
 	if ($WriteToHost) {


### PR DESCRIPTION
When a user runs `pwr sh x; pwr load y`, since the second command is not at offset 1, the load does not get colorized.