### PR TITLE
Add -ScriptBlock Option

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ An `auths.json` might look like:
 # Usage
 
 	SYNTAX
-		pwr [[-Command] <String>] [[-Packages] <String[]>] [-Repositories <String[]>] [-Fetch] [-Installed] [-AssertMinimum <String>] [-Offline] [-Quiet] [-Silent] [-Override] [-Run <String>] [-WhatIf]
+		pwr [[-Command] <String>] [[-Packages] <String[]>] [-Repositories <String[]>] [-Fetch] [-Installed] [-AssertMinimum <String>] [-Offline] [-Quiet] [-Silent] [-Override] [-Run <ScriptBlock>|<String[]>] [-WhatIf]
 
 	PARAMETERS
 		-Command <String>
@@ -158,7 +158,7 @@ An `auths.json` might look like:
 			Use with the `remove` command to show the dry-run of packages to remove
 
 		-Run <String>
-			Executes the user-defined script inside a shell session
+			Executes a script block or user-defined script inside a shell session and then terminates the session
 			The script is declared like `{ ..., "scripts": { "name": "something to run" } }` in 'pwr.json'
 			To specify a script with parameters, declare it like `{ ..., "scripts": { "name": { "format": "something to run --arg={1}" } } }` in 'pwr.json'
 			Arguments may be provided to the formatted script, referenced in the format as {1}, {2}, etc. ({0} refers to the script name)

--- a/test/run.ps1
+++ b/test/run.ps1
@@ -392,6 +392,24 @@ function Test-Pwr-PruneVersion {
 	}
 }
 
+function Test-Pwr-RunScriptBlock {
+	pwr sh "file:///$PSScriptRoot\pkg1" -Run {
+		Invoke-PwrAssertTrue {
+			$env:any -eq 'thing'
+		}
+	}
+
+	# Throwing an exception still exits the shell
+	$env:any = 'thing'
+	Invoke-PwrAssertThrows {
+		pwr sh "file:///$PSScriptRoot\pkg3" -c {
+			Invoke-PwrAssertTrue { $env:any -eq 'buzzy' }
+			throw
+		}
+	}
+	Invoke-PwrAssertTrue { $env:any -eq 'thing' }
+}
+
 ###### Test Runner ######
 
 if ($MyInvocation.InvocationName -eq '.' -or $MyInvocation.Line -eq '') {
@@ -434,9 +452,7 @@ switch ($TestName) {
 	}
 }
 
-if ($ExitCode -gt 0) {
+if ($ExitCode -ne 0) {
 	Write-Host -ForegroundColor Red "Test failure"
 	exit $ExitCode
-} else {
-	exit 0
 }


### PR DESCRIPTION
This PR adds the `-ScriptBlock` option, which is used to execute an arbitrary script block within a temporary shell. It tries to mimic the functionality provided by `cmd /c ...` and `sh -c ...`. Here's a couple examples:

```powershell
pwr sh jdk -ScriptBlock { javac -version }
pwr sh git -c {
  Get-ChildItem directory -Include '*.sha256' | ForEach-Object {
    pushd $_.Directory
    try {
      sha256sum -c $_.Name
      if ($LASTEXITCODE -ne 0) {
        throw "SHA-256 check failed for '$($_.BaseName)'"
      }
    } finally {
      popd
    }
  }
}
```