### PR TITLE
Add initialization scripts to configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ An `auths.json` might look like:
 # Usage
 
 	SYNTAX
-		pwr [[-Command] <String>] [[-Packages] <String[]>] [-Repositories <String[]>] [-Fetch] [-Installed] [-AssertMinimum <String>] [-Offline] [-Quiet] [-Silent] [-Override] [-Run <String>] [-WhatIf]
+		pwr [[-Command] <String>] [[-Packages] <String[]>] [-Repositories <String[]>] [-Fetch] [-Installed] [-AssertMinimum <String>] [-Offline] [-NoInit] [-Quiet] [-Silent] [-Override] [-Run <String>] [-WhatIf]
 
 	PARAMETERS
 		-Command <String>
@@ -132,6 +132,9 @@ An `auths.json` might look like:
 
 		-Offline [<SwitchParameter>]
 			Prevents attempts to request a web resource
+
+		-NoInit [<SwitchParameter>]
+			Do not run initialization scripts from the configuration file
 
 		-Info [<SwitchParameter>]
 			Displays messages written to the information stream (6), otherwise the InformationPreference value is respected

--- a/src/pwr.ps1
+++ b/src/pwr.ps1
@@ -45,6 +45,8 @@
 	Otherwise, the cached repository is used and updated if older than one day
 .PARAMETER Offline
 	Prevents attempts to request a web resource
+.PARAMETER NoInit
+	Do not run initialization scripts from the configuration file
 .PARAMETER Info
 	Displays messages written to the information stream (6), otherwise the InformationPreference value is respected
 .PARAMETER Quiet
@@ -88,6 +90,7 @@ param (
 	[ValidatePattern('^[1-9][0-9]*$')]
 	[int]$DaysOld,
 	[switch]$Offline,
+	[switch]$NoInit,
 	[switch]$Info,
 	[switch]$Quiet,
 	[switch]$Silent,
@@ -851,6 +854,11 @@ function Enter-Shell {
 				throw $_
 			}
 			Write-PwrOutput "using $($P.Ref)"
+		}
+		if (-not $NoInit) {
+			foreach ($E in $PwrConfig.Init) {
+				Invoke-Expression $E
+			}
 		}
 	} finally {
 		Unlock-PwrLock

--- a/test/pwr.json
+++ b/test/pwr.json
@@ -13,5 +13,8 @@
 			"packages": ["pwr"],
 			"command": "pwr version | Out-Null"
 		}
-	}
+	},
+	"init": [
+		"Set-Alias curl.exe example1.ps1 -Scope Global"
+	]
 }

--- a/test/run.ps1
+++ b/test/run.ps1
@@ -242,6 +242,13 @@ function Test-Pwr-ShellEnvOther {
 	}
 }
 
+function Test-Pwr-ShellInit {
+	pwr sh
+	Invoke-PwrAssertTrue {
+		(curl.exe) -eq 'buzzbazz1'
+	}
+}
+
 function Test-Pwr-ShellGetPkg {
 	pwr sh pwr; pwr exit
 	Invoke-PwrAssertTrue {
@@ -403,6 +410,7 @@ $ExitCode = 0
 function Invoke-PwrTest($fn) {
 	&$script:PowerShell -NoProfile -Command {
 		param($script, $fn)
+		Set-Location $(Split-Path -Parent $script)
 		$env:Path = "$(Split-Path -Parent $script)\..\src;$env:Path"
 		. $script
 


### PR DESCRIPTION
This PR adds the capability to add initialization scripts to the `pwr.json` configuration file. For example:

```json
{
  "packages": ["perl"]
  "init": [
    "Set-Alias make gmake -Scope Global"
  ]
}
```