### PR TITLE
Enable age-based pruning

### DIFF
--- a/src/package.Tests.ps1
+++ b/src/package.Tests.ps1
@@ -212,26 +212,34 @@ Describe 'PrunePackages' {
 							'e340857fffc987' = $null
 							'latest' = 'xyz'
 						}
+						'and-another' = @{
+							'ff7d401461e301' = $null
+							'latest' = 'ijk'
+						}
 					}
 					'metadatadb' = @{
 						'abc' = @{RefCount = 1}
 						'xyz' = @{RefCount = 1}
+						'ijk' = @{RefCount = 1}
 						'fde54e65gd4678' = @{RefCount = 0; Size = 3}
-						'e340857fffc987' = @{RefCount = 0; Size = 5}
+						'e340857fffc987' = @{RefCount = 0; RefLostAt = ((Get-Date) - (New-TimeSpan -Days 8)) | Get-Date -Format FileDateTimeUniversal; Size = 5}
+						'ff7d401461e301' = @{RefCount = 0; RefLostAt = ((Get-Date) - (New-TimeSpan -Days 6)) | Get-Date -Format FileDateTimeUniversal; Size = 7}
 					}
 				}
 			}
 		}
 		It 'Prunes' {
-			$db, $pruned = UninstallOrhpanedPackages
+			$db, $pruned = UninstallOrphanedPackages (New-TimeSpan -Days 7)
 			$pruned.Count | Should -Be 2
 			$db.pkgdb.somepkg.Count | Should -Be 1
 			$db.pkgdb.somepkg.latest | Should -Be 'abc'
 			$db.pkgdb.another.Count | Should -Be 1
 			$db.pkgdb.another.latest | Should -Be 'xyz'
-			$db.metadatadb.count | Should -Be 2
+			$db.metadatadb.count | Should -Be 4
 			$db.metadatadb.fde54e65gd4678 | Should -Be $null
 			$db.metadatadb.e340857fffc987 | Should -Be $null
+			$db.metadatadb.ff7d401461e301.refcount | Should -Be 0
+			$db.metadatadb.ff7d401461e301.size | Should -Be 7
 		}
 	}
 	Context 'Last Package' {
@@ -250,7 +258,7 @@ Describe 'PrunePackages' {
 			}
 		}
 		It 'Prunes' {
-			$db, $pruned = UninstallOrhpanedPackages
+			$db, $pruned = UninstallOrphanedPackages
 			$pruned.Count | Should -Be 1
 			$db.pkgdb.somepkg | Should -Be $null
 			$db.metadatadb.fde54e65gd4678 | Should -Be $null

--- a/src/pwr.Tests.ps1
+++ b/src/pwr.Tests.ps1
@@ -170,6 +170,13 @@ Describe 'Invoke-Airpower' {
 			Should -Invoke -CommandName 'Invoke-AirpowerExec' -Exactly -Times 1 -ParameterFilter { $Packages.Count -eq 2 -and $ScriptBlock.ToString() -eq " 'hi' " }
 		}
 	}
+	Context 'Prune' {
+		It 'Calls UninstallOrphanedPackages with time span' {
+			Mock UninstallOrphanedPackages { }
+			Invoke-Airpower prune (New-TimeSpan -Seconds 3)
+			Should -Invoke -CommandName UninstallOrphanedPackages -Exactly -Times 1 -Scope It -ParameterFilter { $MinTimeSpan -eq (New-TimeSpan -Seconds 3) }
+		}
+	}
 }
 
 Describe 'Invoke-AirpowerRun' {

--- a/src/pwr.ps1
+++ b/src/pwr.ps1
@@ -50,7 +50,7 @@ function Invoke-Airpower {
 				}
 			}
 			'prune' {
-				Invoke-AirpowerPrune
+				Invoke-AirpowerPrune @ArgumentList
 			}
 			{$_ -in 'remove', 'rm'} {
 				if ($PSVersionTable.PSVersion.Major -le 5) {
@@ -153,8 +153,10 @@ function Invoke-AirpowerRemove {
 
 function Invoke-AirpowerPrune {
 	[CmdletBinding()]
-	param ()
-	PrunePackages
+	param (
+		[Nullable[TimeSpan]]$MinTimeSpan
+	)
+	PrunePackages $MinTimeSpan
 }
 
 function Invoke-AirpowerPull {


### PR DESCRIPTION
This PR allows an optional `[TimeSpan]` parameter to be passed to `Airpower prune`, such that any package orphaned before the time span will be pruned:

```pwsh
Airpower prune # Prune all packages
Airpower prune (New-TimeSpan -Days 7) # Prune only packages orphaned for more than one week
```

Note: The time span will only be effective for packages orphaned after this PR is merged, since there currently is no field in the database to indicate when a package was orphaned. So, if you do an `Airpower prune (New-TimeSpan -Days 7)`, all packages orphaned before this PR will be pruned, regardless of when they were actually orphaned.