### PR TITLE
Default exec to nested shell

### DIFF
--- a/src/pwr.ps1
+++ b/src/pwr.ps1
@@ -201,8 +201,7 @@ function Invoke-AirpowerExec {
 	[CmdletBinding()]
 	param (
 		[string[]]$Packages,
-		[Parameter(Mandatory)]
-		[scriptblock]$ScriptBlock
+		[scriptblock]$ScriptBlock = { $Host.EnterNestedPrompt() }
 	)
 	if (-not $Packages) {
 		$Packages = GetConfigPackages


### PR DESCRIPTION
This defaults the `exec` command to enter a nested shell, so only the specified packages are available (i.e. clear + load). It corresponds closely with the old `pwr sh` command.