### PR TITLE
Fix interrupted downloads causing DB corruption

### DIFF
--- a/src/package.ps1
+++ b/src/package.ps1
@@ -277,8 +277,7 @@ function PullPackage {
 	WriteHost "Pulling $($Pkg.Package):$($pkg.Tag | AsTagString)"
 	WriteHost "Digest: $($digest)"
 	$k = 'metadatadb', $digest
-	if ([Db]::ContainsKey($k)) {
-		$m = [Db]::Get($k)
+	if ([Db]::ContainsKey($k) -and ($m = [Db]::Get($k)) -and $m.Size) {
 		$size = $m.Size
 	} else {
 		$manifest = $ref | GetManifest


### PR DESCRIPTION
Closes #95. This basically will just treat an empty DB file as if it doesn't exist. Not sure if there is a way to handle corrupt files, or if that is even something that should be handled.