### PR TITLE
Ignore base image layer

### DIFF
--- a/src/package.ps1
+++ b/src/package.ps1
@@ -319,17 +319,15 @@ function SavePackage {
 	[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 	SetCursorVisible $false
 	try {
-		$manifest = $Resp | GetJsonResponse
+		$layers = $Resp | GetPackageLayers
 		$digest = $Resp | GetDigest
 		$temp = @()
-		foreach ($layer in $manifest.layers) {
-			if ($layer.mediaType -eq 'application/vnd.docker.image.rootfs.diff.tar.gzip') {
-				try {
-					$temp += $layer.Digest | SaveBlob | ExtractTarGz -Digest $digest
-					"$($layer.Digest.Substring('sha256:'.Length).Substring(0, 12)): Pull complete" + ' ' * 60 | WriteConsole
-				} finally {
-					WriteConsole "`n"
-				}
+		foreach ($layer in $layers) {
+			try {
+				$temp += $layer.Digest | SaveBlob | ExtractTarGz -Digest $digest
+				"$($layer.Digest.Substring('sha256:'.Length).Substring(0, 12)): Pull complete" + ' ' * 60 | WriteConsole
+			} finally {
+				WriteConsole "`n"
 			}
 		}
 		foreach ($tmp in $temp) {


### PR DESCRIPTION
This PR makes changes to ignore the base layer from getting pulled or calculated as part of the size. (Since the Windows base layer is no longer a foreign layer, it current gets pulled and extracted into every package directory.) It adds a check to ignore the first layer if there is more than one layer in the manifest. (Another option would be to only pull the last layer, but I figured ignoring the first layer is "safer.")