### PR TITLE
Try all packages before failure

### DIFF
--- a/src/package.ps1
+++ b/src/package.ps1
@@ -96,6 +96,30 @@ function AsPackage {
 	throw "failed to parse package: $Pkg"
 }
 
+function TryEachPackage {
+	param (
+		[Parameter(Mandatory, Position = 0)]
+		[string[]]$Packages,
+		[Parameter(Mandatory, Position = 1)]
+		[scriptblock]$ScriptBlock,
+		[string]$ActionDescription = 'process'
+	)
+	$results = @()
+	$failures = @()
+	foreach ($p in $Packages) {
+		try {
+			$results += $p | &$ScriptBlock
+		} catch {
+			Write-Error $_
+			$failures += $p
+		}
+	}
+	if ($failures.Count -gt 0) {
+		throw "Failed to $ActionDescription packages: $($failures -join ', ')"
+	}
+	return $results
+}
+
 function ResolvePackageRefPath {
 	param (
 		[Parameter(Mandatory, ValueFromPipeline)]

--- a/src/pwr.ps1
+++ b/src/pwr.ps1
@@ -136,9 +136,7 @@ function Invoke-AirpowerLoad {
 	if (-not $Packages) {
 		Write-Error 'no packages provided'
 	}
-	foreach ($p in $Packages) {
-		$p | ResolvePackage | LoadPackage
-	}
+	TryEachPackage $Packages { $Input | ResolvePackage | LoadPackage } -ActionDescription 'load'
 }
 
 function Invoke-AirpowerRemove {
@@ -146,9 +144,7 @@ function Invoke-AirpowerRemove {
 	param (
 		[string[]]$Packages
 	)
-	foreach ($p in $Packages) {
-		$p | AsPackage | RemovePackage
-	}
+	TryEachPackage $Packages { $Input | AsPackage | RemovePackage } -ActionDescription 'remove'
 }
 
 function Invoke-AirpowerPrune {
@@ -168,9 +164,7 @@ function Invoke-AirpowerPull {
 	if (-not $Packages) {
 		Write-Error "no packages provided"
 	}
-	foreach ($p in $Packages) {
-		$p | AsPackage | PullPackage
-	}
+	TryEachPackage $Packages { $Input | AsPackage | PullPackage } -ActionDescription 'pull'
 }
 
 function Invoke-AirpowerRun {
@@ -209,10 +203,7 @@ function Invoke-AirpowerExec {
 	if (-not $Packages) {
 		Write-Error "no packages provided"
 	}
-	$resolved = @()
-	foreach ($p in $Packages) {
-		$resolved += $p | ResolvePackage
-	}
+	$resolved = TryEachPackage $Packages { $Input | ResolvePackage } -ActionDescription 'resolve'
 	ExecuteScript -ScriptBlock $ScriptBlock -Pkgs $resolved
 }
 


### PR DESCRIPTION
This PR makes changes to try all packages (`pull`, `load`, `exec`, `rm`) before failing, instead of failing immediately after the first package that fails. If any of the packages fail, then an error message listing all failed packages is printed after all packages are tried.

The reason for this change is that I am regularly pulling packages behind a corporate firewall / proxy. Some packages sporadically fail to download, and some packages seem to just be blocked. When these failures happen, I have to decipher the `Airpower.ps1` in the project directory and go through each package individually, so the process becomes quite involved and lengthy. With this change, the error message at the end lists all failed packages while all the rest of the packages are still updated.

I realize that typically failing fast is the way to go, but this situation might be an exception (pun intended). If there is heartburn with this PR, maybe we could add a parameter to enable failing after the last package.