### PR TITLE
Add update command

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The path determines where packages and metadata exist on a user's machine. It is
 
 The autoupdate determines if and how often the [update](./doc/airpower-update.md) action is taken. It is a [[timespan]](https://learn.microsoft.com/en-us/dotnet/api/system.timespan) but can be specified and parsed as a `[string]`. The autoupdate mechanism is evaluated upon initialization of the `airpower` module, meaning once per shell instance in which you use an `airpower` command.
 
-For example, if `AirpowerAutoupdate` is set to `'1.00:00:00'`, then update will execute at most once per day, unless the `update` command is invoked explicitly.
+For example, if `AirpowerAutoupdate` is set to `'1.00:00:00'`, then update will only automatically execute for packages that were last updated at least one day ago.
 
 > The default `AirpowerAutoupdate` is `$null`
 
@@ -81,7 +81,7 @@ For example, if `AirpowerAutoupdate` is set to `'1.00:00:00'`, then update will 
 
 The autoprune determines if and how often the [prune](./doc/airpower-prune.md) action is taken. It is a [[timespan]](https://learn.microsoft.com/en-us/dotnet/api/system.timespan) but can be specified and parsed as a `[string]`. The autoprune mechanism is evaluated upon initialization of the `airpower` module, meaning once per shell instance in which you use an `airpower` command.
 
-For example, if `AirpowerAutoprune` is set to `'1.00:00:00'`, then prune will execute at most once per day, unless the `prune` command is invoked explicitly.
+For example, if `AirpowerAutoprune` is set to `'1.00:00:00'`, then prune will only automatically execute for packages that have been orphaned for at least one day.
 
 > The default `AirpowerAutoprune` is `$null`.
 

--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Command | Description
 [`load`](./doc/airpower-load.md) | Loads packages into the PowerShell session
 [`exec`](./doc/airpower-exec.md) | Runs a user-defined scriptblock in a managed PowerShell session
 [`run`](./doc/airpower-run.md) | Runs a user-defined scriptblock provided in a project file
+[`update`](./doc/airpower-update.md) | Updates all tagged packages
 [`prune`](./doc/airpower-prune.md) | Deletes unreferenced packages
 [`remove`](./doc/airpower-remove.md) | Untags and deletes packages
 [`help`](./doc/airpower-help.md) | Outputs usage for this command
@@ -68,11 +69,19 @@ The path determines where packages and metadata exist on a user's machine. It is
 
 > The default `AirpowerPath` is `"$env:LocalAppData\Airpower"`.
 
+### `AirpowerAutoupdate`
+
+The autoupdate determines if and how often the [update](./doc/airpower-update.md) action is taken. It is a [[timespan]](https://learn.microsoft.com/en-us/dotnet/api/system.timespan) but can be specified and parsed as a `[string]`. The autoupdate mechanism is evaluated upon initialization of the `airpower` module, meaning once per shell instance in which you use an `airpower` command.
+
+For example, if `AirpowerAutoupdate` is set to `'1.00:00:00'`, then update will execute at most once per day, unless the `update` command is invoked explicitly.
+
+> The default `AirpowerAutoupdate` is `$null`
+
 ### `AirpowerAutoprune`
 
-The autoprune determines if and how often the [prune](./airpower-prune.md) action is taken. It is a [[timespan]](https://learn.microsoft.com/en-us/dotnet/api/system.timespan) but can be specified and parsed as a `[string]`. The autoprune mechanism is evaluated upon initialization of the `airpower` module, meaning once per shell instance in which you use an `airpower` command.
+The autoprune determines if and how often the [prune](./doc/airpower-prune.md) action is taken. It is a [[timespan]](https://learn.microsoft.com/en-us/dotnet/api/system.timespan) but can be specified and parsed as a `[string]`. The autoprune mechanism is evaluated upon initialization of the `airpower` module, meaning once per shell instance in which you use an `airpower` command.
 
-For example, if `AirpowerAutoprune` is set to `'1.00:00:00'`, then prune will execute at most once per day.
+For example, if `AirpowerAutoprune` is set to `'1.00:00:00'`, then prune will execute at most once per day, unless the `prune` command is invoked explicitly.
 
 > The default `AirpowerAutoprune` is `$null`.
 

--- a/doc/airpower-help.md
+++ b/doc/airpower-help.md
@@ -21,6 +21,7 @@ Commands:
   load           Loads packages into the PowerShell session
   exec           Runs a user-defined scriptblock in a managed PowerShell session
   run            Runs a user-defined scriptblock provided in a project file
+  update         Updates all tagged packages
   prune          Deletes unreferenced packages
   remove         Untags and deletes packages
   help           Outputs usage for this command

--- a/doc/airpower-list.md
+++ b/doc/airpower-list.md
@@ -2,6 +2,8 @@
 
 Outputs a list of installed packages.
 
+Packages which display a non-sha256 hash are eligible to be updated via the `update` command
+
 When a displayed package has an empty tag, it is considered *orphaned* and eligible to be pruned via the `prune` command.
 
 ## Usage

--- a/doc/airpower-update.md
+++ b/doc/airpower-update.md
@@ -1,0 +1,17 @@
+# prune
+
+Updates all tagged packages.
+
+## Usage
+
+	airpower update
+
+## Example
+
+```
+PS C:\example> airpower update
+Pulling nasm:latest
+Digest: sha256:db2a58b317e90e537aa1e9b9ab4f1875689bcd9d25a20abdfbf96d3cb0a5ec45
+Status: Package is up to date for nasm:latest
+Updated 0 packages
+```

--- a/doc/airpower-update.md
+++ b/doc/airpower-update.md
@@ -1,4 +1,4 @@
-# prune
+# update
 
 Updates all tagged packages.
 

--- a/doc/airpower-update.md
+++ b/doc/airpower-update.md
@@ -10,8 +10,8 @@ Updates all tagged packages.
 
 ```
 PS C:\example> airpower update
-Pulling nasm:latest
+Pulling somepkg:latest
 Digest: sha256:db2a58b317e90e537aa1e9b9ab4f1875689bcd9d25a20abdfbf96d3cb0a5ec45
-Status: Package is up to date for nasm:latest
+Status: Package is up to date for somepkg:latest
 Updated 0 packages
 ```

--- a/src/config.Tests.ps1
+++ b/src/config.Tests.ps1
@@ -1,0 +1,34 @@
+BeforeAll {
+	. $PSCommandPath.Replace('.Tests.ps1', '.ps1')
+}
+
+Describe 'FindConfig' {
+	BeforeAll {
+		$script:AirpowerPath = "$root\airpower"
+		Mock Get-Location {
+			@{Path = 'C:\a\b\c\d'}
+		}
+	}
+	It 'Local config' {
+		Mock Test-Path {
+			return $true
+		}
+		$cfg = FindConfig
+		$cfg | Should -Be 'C:\a\b\c\d\Airpower.ps1'
+	}
+	It 'Parent config' {
+		$script:i = 0
+		Mock Test-Path {
+			return ($script:i++) -gt 0
+		}
+		$cfg = FindConfig
+		$cfg | Should -Be 'C:\a\b\c\Airpower.ps1'
+	}
+	It 'No config' {
+		Mock Test-Path {
+			return $false
+		}
+		$cfg = FindConfig
+		$cfg | Should -Be $null
+	}
+}

--- a/src/config.ps1
+++ b/src/config.ps1
@@ -47,6 +47,14 @@ function GetAirpowerAutoprune {
 	}
 }
 
+function GetAirpowerAutoupdate {
+	if ($AirpowerAutoupdate) {
+		$AirpowerAutoupdate
+	} elseif ($env:AirpowerAutoupdate) {
+		$env:AirpowerAutoupdate
+	}
+}
+
 function GetPwrDBPath {
 	"$(GetAirpowerPath)\cache"
 }

--- a/src/db.ps1
+++ b/src/db.ps1
@@ -27,11 +27,9 @@ class FileLock {
 	}
 
 	Unlock() {
-		if ($this.Buffer) {
-			if ($this.Buffer.Length -gt 0) {
-				$this.File.SetLength(0)
-				$this.Buffer.WriteTo($this.File)
-			}
+		if ($this.Buffer -and $this.Buffer.Length -gt 0) {
+			$this.File.SetLength(0)
+			$this.Buffer.WriteTo($this.File)
 		}
 		$this.File.Dispose()
 		if ($this.Delete) {
@@ -54,7 +52,7 @@ class FileLock {
 	}
 
 	Put([object]$Value) {
-		$content = [Db]::Encode($value)
+		$content = [Db]::Encode($Value)
 		$this.Buffer.Write([Text.Encoding]::UTF8.GetBytes($content), 0, [Text.Encoding]::UTF8.GetByteCount($content))
 	}
 }
@@ -88,15 +86,6 @@ class Db {
 
 	static Put([string[]]$key, [object]$value) {
 		[IO.File]::WriteAllText("$([Db]::Dir)\$([Db]::Key($key))", [Db]::Encode($value))
-	}
-
-	static [bool] TryPut([string[]]$key, [object]$value) {
-		try {
-			[Db]::TryPut($key, $value)
-			return $true
-		} catch {
-			return $false
-		}
 	}
 
 	static [string] Encode([object]$value) {
@@ -200,4 +189,3 @@ class Entry {
 	[string[]]$Key
 	[object]$Value
 }
-

--- a/src/package.Tests.ps1
+++ b/src/package.Tests.ps1
@@ -330,7 +330,32 @@ Describe 'PrunePackages' {
 		}
 		It 'Prunes' {
 			PrunePackages -Auto
-			Should -Invoke -CommandName 'UninstallOrphanedPackages' -Exactly -Times 1 -ParameterFilter { $span -eq [timespan]::new(4, 11, 22, 33) }
+			Should -Invoke -CommandName 'UninstallOrphanedPackages' -Exactly -Times 1 -ParameterFilter { $Span -eq [timespan]::new(4, 11, 22, 33) }
+		}
+	}
+}
+
+Describe 'UpdatePackages' {
+	BeforeEach {
+		[Db]::Init()
+	}
+	AfterEach {
+		[IO.Directory]::Delete("\\?\$root\airpower", $true)
+	}
+	Context 'From DB' {
+		# TODO
+	}
+	Context 'Auto' {
+		BeforeAll {
+			Mock GetOutofdatePackages { @() }
+			$script:AirpowerAutoupdate = "4.11:22:33"
+		}
+		AfterAll {
+			$script:AirpowerAutoupdate = $null
+		}
+		It 'Updates' {
+			UpdatePackages -Auto
+			Should -Invoke -CommandName 'GetOutofdatePackages' -Exactly -Times 1 -ParameterFilter { $Span -eq [timespan]::new(4, 11, 22, 33) }
 		}
 	}
 }

--- a/src/package.ps1
+++ b/src/package.ps1
@@ -340,6 +340,7 @@ function PullPackage {
 			$locks.Revert()
 		}
 	}
+	return $status
 }
 
 function SavePackage {
@@ -569,9 +570,13 @@ function UpdatePackages {
 	}
 	$span = if ($Auto) { [timespan]::Parse((GetAirpowerAutoupdate)) } else { [timespan]::Zero }
 	$pkgs = GetOutofdatePackages $span
+	$updated = 0
 	foreach ($pkg in $pkgs) {
 		try {
-			$pkg | AsPackage | PullPackage
+			$status = $pkg | AsPackage | PullPackage
+			if ($status -ne 'uptodate') {
+				++$updated
+			}
 		} catch {
 			if (-not $err) {
 				$err = $_
@@ -581,6 +586,7 @@ function UpdatePackages {
 	if ($err) {
 		throw $err
 	}
+	WriteHost "Updated $updated package$(if ($updated -ne 1) { 's' })"
 }
 
 class Digest {

--- a/src/package.ps1
+++ b/src/package.ps1
@@ -499,10 +499,11 @@ function PrunePackages {
 	param (
 		[switch]$Auto
 	)
-	if ($Auto -and -not (GetAirpowerAutoprune)) {
+	$autoprune = (GetAirpowerAutoprune)
+	if ($Auto -and -not $autoprune) {
 		return
 	}
-	$span = if ($Auto) { [timespan]::Parse((GetAirpowerAutoprune)) } else { [timespan]::Zero }
+	$span = if ($Auto) { [timespan]::Parse($autoprune) } else { [timespan]::Zero }
 	$locks, $pruned = UninstallOrphanedPackages $span
 	try {
 		$bytes = 0
@@ -565,10 +566,11 @@ function UpdatePackages {
 	param (
 		[switch]$Auto
 	)
-	if ($Auto -and -not (GetAirpowerAutoupdate)) {
+	$autoupdate = (GetAirpowerAutoupdate)
+	if ($Auto -and -not $autoupdate) {
 		return
 	}
-	$span = if ($Auto) { [timespan]::Parse((GetAirpowerAutoupdate)) } else { [timespan]::MinValue }
+	$span = if ($Auto) { [timespan]::Parse($autoupdate) } else { [timespan]::MinValue }
 	$pkgs = GetOutofdatePackages $span
 	if ($Auto -and -not $pkgs) {
 		return
@@ -697,7 +699,8 @@ function ResolvePackage {
 	}
 	$pkg = $Ref | AsPackage
 	$digest = $pkg | ResolvePackageDigest
-	switch (GetAirpowerPullPolicy) {
+	$pullpolicy = (GetAirpowerPullPolicy)
+	switch ($pullpolicy) {
 		'IfNotPresent' {
 			if (-not $digest) {
 				$pkg | PullPackage | Out-Null
@@ -714,7 +717,7 @@ function ResolvePackage {
 			$pkg.digest = $pkg | ResolvePackageDigest
 		}
 		default {
-			throw "invalid AirpowerPullPolicy '$(GetAirpowerPullPolicy)'"
+			throw "AirpowerPullPolicy '$pullpolicy' is not valid"
 		}
 	}
 	return $pkg

--- a/src/package.ps1
+++ b/src/package.ps1
@@ -485,7 +485,7 @@ function UninstallOrphanedPackages {
 		throw $err
 	}
 	foreach ($lock in $ls) {
-		if ($lock.Key[2] -match '^sha256:' -and $lock.Key[2] -in $metadata.digest) {
+		if ($lock.Key[2].StartsWith('sha256:') -and $lock.Key[2] -in $metadata.digest) {
 			$locks += $lock
 			$lock.Remove()
 		} else {
@@ -539,7 +539,7 @@ function GetOutofdatePackages {
 	try {
 		foreach ($lock in $locks) {
 			$tag = $lock.Key[2]
-			if ($tag -notmatch '^sha256:') {
+			if (-not $tag.StartsWith('sha256:')) {
 				$mlock, $err = [Db]::TryLock(('metadatadb', $lock.Get()))
 				if ($err) {
 					throw $err
@@ -568,7 +568,7 @@ function UpdatePackages {
 	if ($Auto -and -not (GetAirpowerAutoupdate)) {
 		return
 	}
-	$span = if ($Auto) { [timespan]::Parse((GetAirpowerAutoupdate)) } else { [timespan]::Zero }
+	$span = if ($Auto) { [timespan]::Parse((GetAirpowerAutoupdate)) } else { [timespan]::MinValue }
 	$pkgs = GetOutofdatePackages $span
 	if ($Auto -and -not $pkgs) {
 		return

--- a/src/package.ps1
+++ b/src/package.ps1
@@ -570,6 +570,9 @@ function UpdatePackages {
 	}
 	$span = if ($Auto) { [timespan]::Parse((GetAirpowerAutoupdate)) } else { [timespan]::Zero }
 	$pkgs = GetOutofdatePackages $span
+	if ($Auto -and -not $pkgs) {
+		return
+	}
 	$updated = 0
 	foreach ($pkg in $pkgs) {
 		try {

--- a/src/pwr.ps1
+++ b/src/pwr.ps1
@@ -15,7 +15,7 @@ function Invoke-Airpower {
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory)]
-		[ValidateSet('version', 'v', 'remote', 'list', 'load', 'pull', 'exec', 'run', 'remove', 'rm', 'prune', 'help', 'h')]
+		[ValidateSet('version', 'v', 'remote', 'list', 'load', 'pull', 'exec', 'run', 'remove', 'rm', 'prune', 'update', 'help', 'h')]
 		[string]$Command,
 		[Parameter(ValueFromRemainingArguments)]
 		[object[]]$ArgumentList
@@ -47,6 +47,9 @@ function Invoke-Airpower {
 			}
 			'prune' {
 				Invoke-AirpowerPrune
+			}
+			'update' {
+				Invoke-AirpowerUpdate
 			}
 			{$_ -in 'remove', 'rm'} {
 				if ($PSVersionTable.PSVersion.Major -le 5) {
@@ -147,6 +150,12 @@ function Invoke-AirpowerRemove {
 	TryEachPackage $Packages { $Input | AsPackage | RemovePackage } -ActionDescription 'remove'
 }
 
+function Invoke-AirpowerUpdate {
+	[CmdletBinding()]
+	param ()
+	UpdatePackages
+}
+
 function Invoke-AirpowerPrune {
 	[CmdletBinding()]
 	param ()
@@ -234,6 +243,7 @@ Commands:
   load           Loads packages into the PowerShell session
   exec           Runs a user-defined scriptblock in a managed PowerShell session
   run            Runs a user-defined scriptblock provided in a project file
+  update         Updates all packages
   prune          Deletes unreferenced packages
   remove         Untags and deletes packages
   help           Outputs usage for this command
@@ -270,6 +280,7 @@ Set-Alias -Name 'pwr' -Value 'Invoke-Airpower' -Scope Global
 	if ('Airpower.psm1' -eq (Split-Path $MyInvocation.ScriptName -Leaf)) {
 		# Invoked as a module
 		CheckForUpdates
+		UpdatePackages -Auto
 		PrunePackages -Auto
 	}
 }

--- a/src/pwr.ps1
+++ b/src/pwr.ps1
@@ -243,7 +243,7 @@ Commands:
   load           Loads packages into the PowerShell session
   exec           Runs a user-defined scriptblock in a managed PowerShell session
   run            Runs a user-defined scriptblock provided in a project file
-  update         Updates all packages
+  update         Updates all tagged packages
   prune          Deletes unreferenced packages
   remove         Untags and deletes packages
   help           Outputs usage for this command


### PR DESCRIPTION
- Adds the `airpower update` command, which updates all tagged packages (non-sha256 hash tagged packages)
- Add auto-update alongside the existing auto-prune functionality
- Cleanup code in `db`, including the `TryPut` function which was not called anywhere (and was infinitely recursive)
- Fixes a bunch of miscellaneous documentation