### PR TITLE
Remove package status print out

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,14 @@ Set-PSRepository -Name PSGallery -InstallationPolicy Trusted
 
 See the [Airpower PS Gallery](https://www.powershellgallery.com/packages/Airpower) for other installation methods.
 
+# Updating
+
+Use this PowerShell command to update Airpower:
+
+```PowerShell
+Update-Module Airpower
+```
+
 # Usage
 
 Airpower is provided by the `Invoke-Airpower` commandlet. Several aliases are provided for ease-of-use: `airpower`, `air`, and `pwr`.
@@ -71,7 +79,7 @@ The path determines where packages and metadata exist on a user's machine. It is
 
 ### `AirpowerAutoupdate`
 
-The autoupdate determines if and how often the [update](./doc/airpower-update.md) action is taken. It is a [[timespan]](https://learn.microsoft.com/en-us/dotnet/api/system.timespan) but can be specified and parsed as a `[string]`. The autoupdate mechanism is evaluated upon initialization of the `airpower` module, meaning once per shell instance in which you use an `airpower` command.
+The autoupdate determines if and how often the [update](./doc/airpower-update.md) action is taken. It is a [`[timespan]`](https://learn.microsoft.com/en-us/dotnet/api/system.timespan) but can be specified and parsed as a `[string]`. The autoupdate mechanism is evaluated upon initialization of the `airpower` module, meaning once per shell instance in which you use an `airpower` command.
 
 For example, if `AirpowerAutoupdate` is set to `'1.00:00:00'`, then update will only automatically execute for packages that were last updated at least one day ago.
 
@@ -79,7 +87,7 @@ For example, if `AirpowerAutoupdate` is set to `'1.00:00:00'`, then update will 
 
 ### `AirpowerAutoprune`
 
-The autoprune determines if and how often the [prune](./doc/airpower-prune.md) action is taken. It is a [[timespan]](https://learn.microsoft.com/en-us/dotnet/api/system.timespan) but can be specified and parsed as a `[string]`. The autoprune mechanism is evaluated upon initialization of the `airpower` module, meaning once per shell instance in which you use an `airpower` command.
+The autoprune determines if and how often the [prune](./doc/airpower-prune.md) action is taken. It is a [`[timespan]`](https://learn.microsoft.com/en-us/dotnet/api/system.timespan) but can be specified and parsed as a `[string]`. The autoprune mechanism is evaluated upon initialization of the `airpower` module, meaning once per shell instance in which you use an `airpower` command.
 
 For example, if `AirpowerAutoprune` is set to `'1.00:00:00'`, then prune will only automatically execute for packages that have been orphaned for at least one day.
 

--- a/src/pwr.Tests.ps1
+++ b/src/pwr.Tests.ps1
@@ -251,7 +251,7 @@ Describe 'CheckForUpdates' {
 		}
 		It 'Writes Host' {
 			CheckForUpdates
-			Should -Invoke -CommandName 'WriteHost' -Exactly -Times 1
+			Should -Invoke -CommandName 'WriteHost' -Exactly -Times 2
 		}
 	}
 }

--- a/src/pwr.ps1
+++ b/src/pwr.ps1
@@ -173,7 +173,7 @@ function Invoke-AirpowerPull {
 	if (-not $Packages) {
 		Write-Error "no packages provided"
 	}
-	TryEachPackage $Packages { $Input | AsPackage | PullPackage } -ActionDescription 'pull'
+	TryEachPackage $Packages { $Input | AsPackage | PullPackage | Out-Null } -ActionDescription 'pull'
 }
 
 function Invoke-AirpowerRun {
@@ -265,6 +265,7 @@ function CheckForUpdates {
 			$local = [Version]::new((Import-PowerShellDataFile -Path "$PSScriptRoot\Airpower.psd1").ModuleVersion)
 			if ($remote -gt $local) {
 				WriteHost "$([char]27)[92mA new version of Airpower is available! [v$remote]$([char]27)[0m"
+				WriteHost "$([char]27)[92mUse command ``Update-Module Airpower`` for the latest version$([char]27)[0m"
 			}
 		}
 	} catch {


### PR DESCRIPTION
- Fixes an issue where the package status would be printed
- Added instructions on how to update to the latest version of Airpower