### PR TITLE
Add exact version to database

### DIFF
--- a/src/package.Tests.ps1
+++ b/src/package.Tests.ps1
@@ -444,6 +444,7 @@ Describe 'GetLocalPackages' {
 			$pkgs[0].Package | Should -Be $null
 			$pkgs[0].Tag | Should -Be $null
 			$pkgs[0].Digest | Should -Be $null
+			$pkgs[0].Version | Should -Be $null
 			$pkgs[0].Size | Should -Be $null
 		}
 	}
@@ -453,6 +454,7 @@ Describe 'GetLocalPackages' {
 			[Db]::Put(('pkgdb', 'somepkg', 'latest'), $digest)
 			[Db]::Put(('metadatadb', $digest), @{
 				RefCount = 1
+				Version = "1"
 				Size = 293874
 			})
 		}
@@ -462,6 +464,7 @@ Describe 'GetLocalPackages' {
 			$pkgs[0].Package | Should -Be 'somepkg'
 			$pkgs[0].Tag | Should -Be 'latest'
 			$pkgs[0].Digest.Sha256 | Should -Be $digest
+			$pkgs[0].Version | Should -Be "1"
 			$pkgs[0].Size.Bytes | Should -Be 293874
 		}
 	}

--- a/src/package.ps1
+++ b/src/package.ps1
@@ -153,7 +153,8 @@ function ResolveRemoteRef {
 			$eq = $eq -and $want.Build -eq $got.Build
 		}
 		if ($eq) {
-			return "$($Pkg.Package)-$(($got.ToString()).Replace('+', '_'))"
+			$Pkg.Version = $got.ToString()
+			return "$($Pkg.Package)-$($Pkg.Version.Replace('+', '_'))"
 		}
 	}
 	throw "no such $($Pkg.Package) tag: $($Pkg.Tag)"
@@ -174,6 +175,7 @@ function GetLocalPackages {
 			$pkgs += [LocalPackage]@{
 				Package = $lock.Key[1]
 				Tag = $t
+				Version = $m.Version
 				Digest = $digest | AsDigest
 				Size = $m.size | AsSize
 				Updated = if ($m.updated) { [datetime]::Parse($m.updated) } else { }
@@ -248,6 +250,7 @@ function InstallPackage { # $locks, $status
 		{$_ -in 'new', 'newer'} {
 			$mLock.Put(@{
 				RefCount = 1
+				Version = $Pkg.Version
 				Size = $Pkg.Size
 				Updated = [datetime]::UtcNow.ToString()
 			})
@@ -759,6 +762,7 @@ function AsSize {
 class LocalPackage {
 	[object]$Package
 	[Tag]$Tag
+	[string]$Version
 	[Digest]$Digest
 	[Size]$Size
 	[object]$Updated


### PR DESCRIPTION
This PR adds tracking the actual installed version for each package, which can be retrieved using `Airpower list`.

This stems from the issue that it's currently not feasible to find out exactly which version of a package was pulled. (i.e., did `Airpower pull jdk` pull `jdk:17.0.2`, `jdk:17.0.3+1`, etc.; did `Airpower pull vs-buildtools:17.4` pull `vs-buildtools:17.4.6`, vs-buildtools:17.4.7`, etc.) `Airpower list` currently does not provide this information, so you would have to go back to Docker Hub and look up the digest and correlate it with the version. Unfortunately, this information cannot easily be obtained using the Docker Hub API without iterating every tag, so I decided it would be better to save off the version information when a package is pulled, which means it would only affect new pulls.

Here is an example:

```pwsh
PS C:\Users\***> pwr list | where { $_.Package -eq 'cmake-converter' }

Package  : cmake-converter
Tag      : latest
Version  : 2.2.0+1
Digest   : b7d550f89cd8
Size     : 1.39 kB
Updated  : 7/1/2024 2:12:26 AM
Orphaned :
```