### PR TITLE
Add Offline Repositories

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Command | Description
 [`update`](./doc/airpower-update.md) | Updates all tagged packages
 [`prune`](./doc/airpower-prune.md) | Deletes unreferenced packages
 [`remove`](./doc/airpower-remove.md) | Untags and deletes packages
+[`save`](./doc/airpower-save.md) | Downloads packages for use in an offline installation
 [`help`](./doc/airpower-help.md) | Outputs usage for this command
 
 # Configuration

--- a/doc/airpower-help.md
+++ b/doc/airpower-help.md
@@ -24,6 +24,7 @@ Commands:
   update         Updates all tagged packages
   prune          Deletes unreferenced packages
   remove         Untags and deletes packages
+  save           Downloads packages for use in an offline installation
   help           Outputs usage for this command
 
 For detailed documentation and examples, visit https://github.com/airpwr/airpwr.

--- a/doc/airpower-save.md
+++ b/doc/airpower-save.md
@@ -1,0 +1,20 @@
+# save
+
+Downloads packages for use in an offline installation.
+
+Packages are pulled and saved locally in the specified output directory.
+
+An array of packages are accepted as input.
+
+## Usage
+
+	airpower save <package>[:tag]... <output directory>
+
+## Example
+
+```
+PS C:\example> airpower save somepkg airpower-cache
+Pulling somepkg:latest
+Digest: sha256:db2a58b317e90e537aa1e9b9ab4f1875689bcd9d25a20abdfbf96d3cb0a5ec45
+d47df44424b8: Pull complete
+```

--- a/src/config.ps1
+++ b/src/config.ps1
@@ -29,6 +29,14 @@ function GetAirpowerPath {
 	}
 }
 
+function GetAirpowerRepo {
+	if ($AirpowerRepo) {
+		$AirpowerRepo
+	} elseif ($env:AirpowerRepo) {
+		$env:AirpowerRepo
+	}
+}
+
 function GetAirpowerPullPolicy {
 	if ($AirpowerPullPolicy) {
 		$AirpowerPullPolicy

--- a/src/pwr.ps1
+++ b/src/pwr.ps1
@@ -15,7 +15,7 @@ function Invoke-Airpower {
 	[CmdletBinding()]
 	param (
 		[Parameter(Mandatory)]
-		[ValidateSet('version', 'v', 'remote', 'list', 'load', 'pull', 'exec', 'run', 'remove', 'rm', 'prune', 'update', 'help', 'h')]
+		[ValidateSet('version', 'v', 'remote', 'list', 'load', 'pull', 'exec', 'run', 'remove', 'rm', 'save', 'prune', 'update', 'help', 'h')]
 		[string]$Command,
 		[Parameter(ValueFromRemainingArguments)]
 		[object[]]$ArgumentList
@@ -57,6 +57,10 @@ function Invoke-Airpower {
 				} else {
 					Invoke-AirpowerRemove $ArgumentList
 				}
+			}
+			'save' {
+				$params, $remaining = ResolveParameters 'Invoke-AirpowerSave' $ArgumentList
+				Invoke-AirpowerSave @params @remaining
 			}
 			'exec' {
 				$params, $remaining = ResolveParameters 'Invoke-AirpowerExec' $ArgumentList
@@ -236,6 +240,25 @@ function Invoke-AirpowerRemote {
 	}
 }
 
+function Invoke-AirpowerSave {
+	[CmdletBinding()]
+	param (
+		[string[]]$Packages,
+		[Parameter(Mandatory)]
+		[string]$Output
+	)
+	if (-not $Packages) {
+		$Packages = GetConfigPackages
+	}
+	if (-not $Packages) {
+		Write-Error "no packages provided"
+	}
+	if (-not $Output) {
+		Write-Error "no output directory provided"
+	}
+	TryEachPackage $Packages { $Input | AsPackage | PullPackage -Output $Output | Out-Null } -ActionDescription 'save'
+}
+
 function Invoke-AirpowerHelp {
 @"
 
@@ -252,6 +275,7 @@ Commands:
   update         Updates all tagged packages
   prune          Deletes unreferenced packages
   remove         Untags and deletes packages
+  save           Downloads packages for use in an offline installation
   help           Outputs usage for this command
 
 For detailed documentation and examples, visit https://github.com/airpwr/airpwr.


### PR DESCRIPTION
This adds support for saving manifests and packages to an offline repository directory using the `$AirpowerSaveRepo` or `$env:AirpowerSaveRepo` variables.

This offline repository directory can be used by setting the `$AirpowerRepo` or `$env:AirpowerRepo`.

UPDATE 12/18/2024:

I have implemented an `Airpower save git, go, rust -Output airpower-cache` function to save packages for offline installation instead of using the `$env:AirpowerSaveRepo` variable. So, general use would look something like this:

```pwsh
Airpower save git, go, rust -Output airpower-cache
# Copy airpower-cache directory to an offline computer with Airpower installed
$AirpowerRepo = 'airpower-cache'
Airpower pull git
```